### PR TITLE
nginx_upstream_check_module also has the port option for configuring a different port for checks

### DIFF
--- a/manifests/upstream.pp
+++ b/manifests/upstream.pp
@@ -9,6 +9,7 @@ define nginx::upstream(
   $check_timeout = 1000,
   $check_default_down = true,
   $check_type = 'tcp',
+  $check_port = '',
   $check_keepalive_requests = 1,
   $check_http_send = '',
   $check_http_expect_alive = '',

--- a/templates/upstream.footer.erb
+++ b/templates/upstream.footer.erb
@@ -1,6 +1,7 @@
 <% if @check_health != false -%>
 <%= "check interval=#{@check_interval} rise=#{@check_rise} fall=#{@check_fall} " -%>
 <%= "timeout=#{@check_timeout} default_down=#{@check_default_down} type=#{@check_type};" %>
+<%= "check port=#{@check_port};" if @check_port != '' %>
 <%= "check_keepalive_requests #{@check_keepalive_requests};" if @check_keepalive_requests != '' %>
 <%= "check_http_send \"#{@check_http_send}\";" if @check_http_send != '' %>
 <%= "check_http_expect_alive #{@check_http_expect_alive};" if  @check_http_expect_alive != '' %>


### PR DESCRIPTION
Unfortunately nginx_upstream_check_module does not yet support TLS.

This PR adds the option to configure a different port for the health checks.
