### PR TITLE
Everything needs to be on a single line

### DIFF
--- a/templates/upstream.footer.erb
+++ b/templates/upstream.footer.erb
@@ -1,7 +1,7 @@
 <% if @check_health != false -%>
 <%= "check interval=#{@check_interval} rise=#{@check_rise} fall=#{@check_fall} " -%>
+<%= "port=#{@check_port} " if @check_port != '' -%>
 <%= "timeout=#{@check_timeout} default_down=#{@check_default_down} type=#{@check_type};" %>
-<%= "check port=#{@check_port};" if @check_port != '' %>
 <%= "check_keepalive_requests #{@check_keepalive_requests};" if @check_keepalive_requests != '' %>
 <%= "check_http_send \"#{@check_http_send}\";" if @check_http_send != '' %>
 <%= "check_http_expect_alive #{@check_http_expect_alive};" if  @check_http_expect_alive != '' %>


### PR DESCRIPTION
After further testing I've found that all the check options need to be in the same line, otherwise it will only keep the values configured in the last check line.

```
check interval=1000 rise=2 fall=5 default_down=false type=http;
check port=80;
```

The above configuration ignores the options defined in the first check and uses the default values for everything.
