### PR TITLE
add path param to rebuilt-nginx-upstream exec resource

### DIFF
--- a/manifests/upstream.pp
+++ b/manifests/upstream.pp
@@ -14,7 +14,7 @@ define nginx::upstream(
   $check_http_send = '',
   $check_http_expect_alive = '',
 ) {
-  
+
   validate_bool($check_health)
   validate_bool($check_default_down)
   validate_re($check_type, ['^tcp$','^http$','^ssl_hello$','^mysql$','^ajp$','^fastcgi$'])
@@ -68,5 +68,6 @@ define nginx::upstream(
     refreshonly => true,
     require     => File[$target_dir],
     notify      => Exec['reload-nginx'],
+    path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin']
   }
 }


### PR DESCRIPTION
The generating of the upstream config file doesn't appear to be happening unless its done from a shell, which has a full path. Add the `path` param to the exec statement so that it knows where to find its commands.
