### PR TITLE
Fixes restart nginx to ensure we don't restart nginx if config is wrong

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,23 +1,30 @@
-define nginx::config($ensure = 'present', $source = '', $content = '') {
- validate_string($source, $content)
+# Class to manage NGinx configs
+define nginx::config(
+  $ensure  = 'present',
+  $source  = '',
+  $content = ''
+) {
+
+  validate_string($source, $content)
+
   if ($ensure != 'present' and $ensure != 'absent') {
-    fail("Nginx::Config[$name] ensure should be one of present/absent")
+    fail("Nginx::Config[${name}] ensure should be one of present/absent")
   }
 
   if (!$content and !$source and $ensure != 'absent') {
-    fail("Nginx::Config[$name] either source or content must be present")
+    fail("Nginx::Config[${name}] either source or content must be present")
   }
   elsif ($content and $source) {
-    fail("Nginx::Config[$name] cannot specify both source and content")
+    fail("Nginx::Config[${name}] cannot specify both source and content")
   }
 
   $conf_path   = "/etc/nginx/conf.d/${name}.conf"
 
   File {
-    notify => Exec['reload-nginx'],
     ensure => $ensure,
     owner  => 'root',
     group  => 'root',
+    notify => Service['nginx'],
   }
 
   if ($content) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,11 +20,6 @@ class nginx(
     subscribe  => File['/etc/nginx/nginx.conf'],
   }
 
-  exec { 'reload-nginx':
-    command     => '/etc/init.d/nginx reload',
-    refreshonly => true,
-  }
-
   file { ['/etc/nginx/conf.d/',
     '/etc/nginx/upstreams.d/',
     '/etc/nginx/sites-enabled',
@@ -48,7 +43,7 @@ class nginx(
     group   => 'root',
     mode    => '0644',
     require => Package['nginx'],
-    notify  => Exec['reload-nginx'],
+    notify  => Service['nginx'],
   }
 
   $use_fastcgi_params = $fastcgi_params ? {
@@ -63,7 +58,7 @@ class nginx(
     group   => 'root',
     mode    => '0644',
     require => Package['nginx'],
-    notify  => Exec['reload-nginx'],
+    notify  => Service['nginx'],
   }
 
   file { '/var/cache/nginx/':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,11 @@ class nginx(
     subscribe  => File['/etc/nginx/nginx.conf'],
   }
 
+  exec { 'reload-nginx':
+    command     => '/etc/init.d/nginx reload',
+    refreshonly => true,
+  }
+
   file { ['/etc/nginx/conf.d/',
     '/etc/nginx/upstreams.d/',
     '/etc/nginx/sites-enabled',

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,4 +1,10 @@
-define nginx::site($ensure = "present", $source = '', $content = '') {
+# Class to manage site resources
+define nginx::site(
+  $ensure  = 'present',
+  $source  = '',
+  $content = '',
+) {
+
   File {
     ensure => $ensure ? {
       'absent' => 'absent',
@@ -7,37 +13,37 @@ define nginx::site($ensure = "present", $source = '', $content = '') {
     owner  => 'root',
     group  => 'root',
     mode   => '0640',
-    notify => Exec['reload-nginx'],
+    notify => Service['nginx'],
     require => File[
       '/etc/nginx/sites-available',
       '/etc/nginx/sites-enabled'
-    ]
+    ],
   }
 
   $config_file = "/etc/nginx/sites-available/${name}"
 
-	if ($source) {
-		file { $config_file:
-			source => $source,
-		}
-	}
+  if ($source) {
+    file { $config_file:
+      source => $source,
+    }
+  }
   elsif ($content) {
     file { $config_file:
       content => $content,
     }
   }
 
-  if $ensure == "present" {
+  if $ensure == 'present' {
     file { "/etc/nginx/sites-enabled/${name}":
       ensure => $config_file,
     }
   }
   else {
     file { "/etc/nginx/sites-enabled/${name}":
-      ensure => absent,
+      ensure => 'absent',
       # This should still notify the service, as a reload will not
       # stop listening.
-      notify => Service["nginx"],
+      notify => Service['nginx'],
     }
   }
 }

--- a/manifests/upstream.pp
+++ b/manifests/upstream.pp
@@ -31,7 +31,7 @@ define nginx::upstream(
   }
 
   file { $target_dir:
-    ensure => $ensure ? {
+    ensure  => $ensure ? {
       'present' => 'directory',
       'absent'  => 'absent',
     },
@@ -42,7 +42,7 @@ define nginx::upstream(
 
   file { $target_file:
     replace => false,
-    notify  => Exec['reload-nginx'],
+    notify  => Service['nginx'],
   }
 
   file { "${target_dir}/0_header.conf":
@@ -67,6 +67,6 @@ define nginx::upstream(
     command     => $command,
     refreshonly => true,
     require     => File[$target_dir],
-    notify      => Exec['reload-nginx'],
+    notify      => Service['nginx'],
   }
 }

--- a/manifests/upstream/member.pp
+++ b/manifests/upstream/member.pp
@@ -1,12 +1,13 @@
+# Class to manage nginx site upstreams
 define nginx::upstream::member(
   $upstream,
-  $ensure = 'present',
-  $host = '',
-  $down = false,
-  $weight = 1,
-  $max_fails = 0,
+  $ensure       = 'present',
+  $host         = '',
+  $down         = false,
+  $weight       = 1,
+  $max_fails    = 0,
   $fail_timeout = 0,
-  $backup = false
+  $backup       = false
 ) {
 
   $use_host = $host ? {
@@ -15,12 +16,12 @@ define nginx::upstream::member(
   }
   $member_path = "/etc/nginx/upstreams.d/${upstream}/1_${name}.conf"
   file { $member_path:
-    owner   => root,
-    group   => root,
-    mode    => 0644,
-    content => template('nginx/upstream.member.erb'),
     ensure  => $ensure,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('nginx/upstream.member.erb'),
     notify  => Exec["rebuild-nginx-upstream-${upstream}"],
-   require  => File["/etc/nginx/upstreams.d/${upstream}/"]
+    require => File["/etc/nginx/upstreams.d/${upstream}/"]
   }
 }


### PR DESCRIPTION
- Adds `restart` attribute to service nginx to ensure that we restart nginx only if the configurations are valid.
- Fix init.pp linting
