### PR TITLE
Enforce syntax validation on nginx before reloading

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,12 +16,12 @@ class nginx(
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    restart    => '/etc/init.d/nginx reload',
+    restart    => 'nginx -t /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
     subscribe  => File['/etc/nginx/nginx.conf'],
   }
 
   exec { 'reload-nginx':
-    command     => '/etc/init.d/nginx reload',
+    command     => 'nginx -t /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
     refreshonly => true,
   }
 


### PR DESCRIPTION
Turns out that 

```
/etc/nginx# /etc/init.d/nginx reload
[FAIL] Reloading nginx configuration: nginx failed!
[integration][sjc1sl][root@public-lb1b-i]:/etc/nginx# echo $?
0 
```

so for puppet's concern nginx reloaded correctly, although it didn't.

This PR ensures that puppet will do checks before even trying to reload and puppet will be notified of this errors.

I will open an issue on Nginx mainline since this is a design error on Nginx init it shouldn't return a `0`
