### PR TITLE
This adds absolute path to nginx binary and fixes test command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,12 +16,12 @@ class nginx(
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    restart    => 'nginx -t /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
+    restart    => '/usr/sbin/nginx -t -c /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
     subscribe  => File['/etc/nginx/nginx.conf'],
   }
 
   exec { 'reload-nginx':
-    command     => 'nginx -t /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
+    command     => '/usr/sbin/nginx -t -c /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
     refreshonly => true,
   }
 


### PR DESCRIPTION
The test command has a missing -c to specify the config file. The right command is the following.

```
:~# nginx -t -c /etc/nginx/nginx.conf
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```
