### PR TITLE
Add missing fields to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,9 @@
     "description": "A different approach to managing nginx sites available/enabled, and configuration includes. Requires Nginx 1.1.11+",
     "author": "Chris Boulton <chris@chrisboulton.com>",
     "source": "https://github.com/chrisboulton/puppet-nginx",
-    "project_page": "https://github.com/chrisboulton/puppet-nginx"
+    "project_page": "https://github.com/chrisboulton/puppet-nginx",
+    "issues_url": "https://github.com/chrisboulton/puppet-nginx/issues",
+    "dependencies": [
+        {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+     ]
 }


### PR DESCRIPTION
In this modules `metadata.json` it is missing the `issues_url` & `dependencies` parameters. Without it puppet doesn't see the module as being valid and so it doesn't become available when you try and compile a puppet catalogue.
