### PR TITLE
Make error and access log file locations configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,8 @@ class nginx(
   $service_ensure  = 'running',
   $user            = 'www-data',
   $group           = 'www-data',
+  $access_log_file = '/var/log/nginx/access.log',
+  $error_log_file  = '/var/log/nginx/error.log',
 ) {
 
   package { 'nginx':

--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -2,7 +2,7 @@ user <%= @user %> <%= @group %>;
 worker_processes 2;
 worker_rlimit_nofile 4096;
 
-error_log /var/log/nginx/error.log;
+error_log <%= @error_log_file %>;
 pid /var/run/nginx.pid;
 
 events {
@@ -20,7 +20,7 @@ http {
 	log_format vhost_combined '$server_name $remote_addr - $remote_user [$time_local]  '
 	                          '"$request" $status $body_bytes_sent '
 	                          '"$http_referer" "$http_user_agent" $request_time $upstream_response_time';
-	access_log /var/log/nginx/access.log vhost_combined;
+	access_log <%= @access_log_file %> vhost_combined;
 
 	keepalive_timeout 4;
 	tcp_nodelay on;


### PR DESCRIPTION
Makes access_log_file and error_log_file arguments for the nginx class, so these can be overridden by the user whilst keeping the rest of the default config file.
