### PR TITLE
Fix typo in file resource, it should be source not config.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,7 @@ class nginx(
 
   if ($config) {
     File['/etc/nginx/nginx.conf'] {
-      config => $config,
+      source => $config,
     }
   } elsif ($content) {
     File['/etc/nginx/nginx.conf'] {

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -3,4 +3,43 @@ require 'spec_helper'
 describe 'nginx' do
   it { is_expected.to compile }
   it { is_expected.to contain_class('nginx') }
+
+  context 'with content and config nginx class should not compile' do
+    let(:params) {
+      {:config  => 'something',
+       :content => 'something'
+      }
+    }
+
+    it { is_expected.not_to  compile }
+  end
+
+  context 'with config nginx class should compile' do
+    let(:params) { {:config => '/etc/nginx/nginx.conf'}}
+
+    it { is_expected.to compile }
+  end
+
+  context 'with content nginx class should compile' do
+    let(:params) { {:content => 'lol'}}
+
+    it { is_expected.to compile }
+  end
+
+  context 'with content => "This is a test"' do
+    let(:params) { {:content => 'This is a test'} }
+
+    it do
+      is_expected.to contain_file('/etc/nginx/nginx.conf') \
+        .with_content(/^This is a test$/)
+    end
+  end
+
+  context 'with no content and no config' do
+    it do
+      is_expected.to contain_file('/etc/nginx/nginx.conf') \
+        .with_content(/worker_processes 2/)
+    end
+  end
+
 end


### PR DESCRIPTION
Fixing a typo I introduced on my last PR.

And because I'm ashamed I'm also adding some tests so this doesn't happen again. I'm just starting with this rspec thing, but this should cover pretty much all the changes I added on my last PR.

```
Finished in 2.17 seconds (files took 0.69305 seconds to load)
7 examples, 0 failures
```
