### PR TITLE
PLATFORM-741: Only reload nginx if it's running, otherwise start instead.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,18 +15,20 @@ class nginx(
     name   => "nginx-${package}",
   }
 
+  $restart_cmd = '/usr/sbin/nginx -t -c /etc/nginx/nginx.conf && (/etc/init.d/nginx status && /etc/init.d/nginx reload || /etc/init.d/nginx start)'
+
   service { 'nginx':
     ensure     => $service_ensure,
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    restart    => '/usr/sbin/nginx -t -c /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
+    restart    => $restart_cmd,
     subscribe  => File['/etc/nginx/nginx.conf'],
   }
 
   if $service_ensure == 'running' {
     exec { 'reload-nginx':
-      command     => '/usr/sbin/nginx -t -c /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
+      command     => $restart_cmd,
       refreshonly => true,
     }
   }


### PR DESCRIPTION
Resolves this error during first puppet run and nginx is _not_ yet running:

```
==> default: Error: /Stage[main]/Nginx/Service[nginx]: Failed to call refresh: Could not restart Service[nginx]: Execution of '/usr/sbin/nginx -t -c /etc/nginx/nginx.conf && /etc/init.d/nginx reload' returned 1: nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
==> default: nginx: configuration file /etc/nginx/nginx.conf test is successful
==> default: Reloading nginx configuration (via systemctl): nginx.serviceJob for nginx.service failed. See 'systemctl status nginx.service' and 'journalctl -xn' for details.
==> default:  failed!
```

```
root@bcapp:/var/run# /etc/init.d/nginx stop
Stopping nginx (via systemctl): nginx.service.

root@bcapp:/var/run# /usr/sbin/nginx -t -c /etc/nginx/nginx.conf && (/etc/init.d/nginx status && /etc/init.d/nginx reload || /etc/init.d/nginx start)
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
● nginx.service - A high performance web server and a reverse proxy server
   Loaded: loaded (/lib/systemd/system/nginx.service; enabled)
   Active: inactive (dead) since Tue 2016-10-11 04:14:22 UTC; 3s ago
  Process: 18333 ExecStop=/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /run/nginx.pid (code=exited, status=0/SUCCESS)
  Process: 18308 ExecReload=/usr/sbin/nginx -g daemon on; master_process on; -s reload (code=exited, status=0/SUCCESS)
  Process: 17720 ExecStart=/usr/sbin/nginx -g daemon on; master_process on; (code=exited, status=0/SUCCESS)
  Process: 17716 ExecStartPre=/usr/sbin/nginx -t -q -g daemon on; master_process on; (code=exited, status=0/SUCCESS)
 Main PID: 17721 (code=exited, status=0/SUCCESS)

Oct 11 04:08:09 bcapp.dev systemd[1]: Started A high performance web server and a reverse proxy server.
Oct 11 04:08:31 bcapp.dev systemd[1]: Started A high performance web server and a reverse proxy server.
Oct 11 04:14:14 bcapp.dev systemd[1]: Reloading A high performance web server and a reverse proxy server.
Oct 11 04:14:14 bcapp.dev systemd[1]: Reloaded A high performance web server and a reverse proxy server.
Oct 11 04:14:18 bcapp.dev systemd[1]: Reloading A high performance web server and a reverse proxy server.
Oct 11 04:14:18 bcapp.dev systemd[1]: Reloaded A high performance web server and a reverse proxy server.
Oct 11 04:14:22 bcapp.dev systemd[1]: Stopping A high performance web server and a reverse proxy server...
Oct 11 04:14:22 bcapp.dev systemd[1]: Stopped A high performance web server and a reverse proxy server.
Nginx master is dead but children are still running. Killing before start
Starting nginx (via systemctl): nginx.service.

root@bcapp:/var/run# /usr/sbin/nginx -t -c /etc/nginx/nginx.conf && (/etc/init.d/nginx status && /etc/init.d/nginx reload || /etc/init.d/nginx start)
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
● nginx.service - A high performance web server and a reverse proxy server
   Loaded: loaded (/lib/systemd/system/nginx.service; enabled)
   Active: active (running) since Tue 2016-10-11 04:14:26 UTC; 3s ago
  Process: 18333 ExecStop=/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /run/nginx.pid (code=exited, status=0/SUCCESS)
  Process: 18308 ExecReload=/usr/sbin/nginx -g daemon on; master_process on; -s reload (code=exited, status=0/SUCCESS)
  Process: 18373 ExecStart=/usr/sbin/nginx -g daemon on; master_process on; (code=exited, status=0/SUCCESS)
  Process: 18370 ExecStartPre=/usr/sbin/nginx -t -q -g daemon on; master_process on; (code=exited, status=0/SUCCESS)
 Main PID: 18374 (nginx)
   CGroup: /system.slice/nginx.service
           ├─18374 nginx: master process /usr/sbin/nginx -g daemon on; master_process on;
           ├─18375 nginx: worker process
           ├─18376 nginx: worker process
           ├─18377 nginx: worker process
           ├─18378 nginx: worker process
           ├─18380 nginx: cache manager process
           └─18381 nginx: cache loader process

Oct 11 04:14:26 bcapp.dev systemd[1]: Started A high performance web server and a reverse proxy server.
Reloading nginx configuration (via systemctl): nginx.service.
```
