### PR TITLE
Make the reload-nginx exec a no-op and notify the service instead.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,10 @@ class nginx(
     subscribe  => File['/etc/nginx/nginx.conf'],
   }
 
+  # DEPRECATED: use `notify => Service['nginx']` instead.
+  # This remains for backwards compatiblity with other modules.
+  # Previously, this would execute the same command as the custom restart above. Both the service and the exec
+  # doing the reload simultaneously would cause a race condition resulting in nginx to fail to reload correctly.
   exec { 'reload-nginx':
     command     => '/usr/bin/env true',
     refreshonly => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,16 +24,14 @@ class nginx(
     subscribe  => File['/etc/nginx/nginx.conf'],
   }
 
-  if $service_ensure == 'running' {
-    exec { 'reload-nginx':
-      command     => '/usr/sbin/nginx -t -c /etc/nginx/nginx.conf && /etc/init.d/nginx reload',
-      refreshonly => true,
-    }
+  exec { 'reload-nginx':
+    command     => '/usr/bin/env true',
+    refreshonly => true,
   }
-  else {
-    exec { 'reload-nginx':
-      command     => '/usr/bin/env true',
-      refreshonly => true,
+
+  if $service_ensure == 'running' {
+    Exec['reload-nginx'] {
+      notify => Service['nginx'],
     }
   }
 


### PR DESCRIPTION
Having both the `service` and the `exec` execute the same command (which seems to occur simultaneously during a puppet apply) causes a race-condition type issue where the pid file gets emptied and the reload fails. Overall this may result in puppet failing and/or the nginx service being in a bad state.

This makes the exec a no-op and instead just notifies the service which upon refresh will execute the custom restart command.

This should be compatible with existing usage and achieve the desired behaviour.
