### PR TITLE
Update list of GZIP compressible types

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -35,7 +35,7 @@ http {
 	gzip_comp_level 4;
 	gzip_http_version 1.1;
 	gzip_min_length 10;
-	gzip_types text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+	gzip_types text/css application/javascript text/plain text/xml application/json application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype application/x-font-ttf application/xml font/eot font/opentype font/otf image/svg+xml image/vnd.microsoft.icon;
 	gzip_vary on;
 	gzip_disable "msie6";
 	gzip_static on;


### PR DESCRIPTION
This uses the same list that we use for our new shared load balancers. The biggest change is the addition of application/json and the removal of application/x-javascript in favour of application/javascript.