### PR TITLE
Make module Puppet 4 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
----
-sudo: false
 language: ruby
-rvm:
-  - 2.2
 cache: bundler
+rvm:
+  - 2.1
+  - 2.2
+gemfile:
+  - gemfiles/puppet3.gemfile
+  - gemfiles/puppet4.gemfile
 script:
   - "bundle exec rake validate"
   - "bundle exec rake lint"

--- a/Rakefile
+++ b/Rakefile
@@ -39,3 +39,5 @@ task :spec_clean do
     FileUtils::rm_f('spec/fixtures/manifests/site.pp')
   end
 end
+
+PuppetSyntax.exclude_paths = ["vendor/**/*", "gemfiles/vendor/**/*", "spec/fixtures/modules/**/*"]

--- a/gemfiles/puppet3.gemfile
+++ b/gemfiles/puppet3.gemfile
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+gem 'puppet', '<4'
+gem 'safe_yaml', '>= 1.0.4'
+gem 'librarian-puppet'
+
+group :development, :test do
+  gem "metadata-json-lint"
+  gem "puppet-lint"
+  gem "puppet-syntax"
+  gem "puppetlabs_spec_helper"
+  gem "rspec"
+  gem "rspec-puppet"
+end

--- a/gemfiles/puppet3.gemfile.lock
+++ b/gemfiles/puppet3.gemfile.lock
@@ -1,0 +1,97 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.3)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
+    fast_gettext (1.1.0)
+    gettext (3.2.2)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.24)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
+      locale
+    hiera (1.3.4)
+      json_pure
+    json (2.1.0)
+    json_pure (2.1.0)
+    librarian-puppet (2.2.3)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 2.1)
+      rsync
+    librarianp (0.6.3)
+      thor (~> 0.15)
+    locale (2.1.2)
+    metaclass (0.0.4)
+    metadata-json-lint (1.1.0)
+      json
+      semantic_puppet (>= 0.1.2, < 2.0.0)
+      spdx-licenses (~> 1.0)
+    minitar (0.6.1)
+    mocha (1.2.1)
+      metaclass (~> 0.0.1)
+    multipart-post (2.0.0)
+    puppet (3.8.7)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
+      json_pure
+    puppet-lint (2.2.1)
+    puppet-syntax (2.4.0)
+      rake
+    puppet_forge (2.2.4)
+      faraday (~> 0.9.0)
+      faraday_middleware (>= 0.9.0, < 0.11.0)
+      gettext-setup (~> 0.11)
+      minitar
+      semantic_puppet (~> 0.1.0)
+    puppetlabs_spec_helper (2.1.2)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
+    rake (12.0.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-puppet (2.5.0)
+      rspec
+    rspec-support (3.5.0)
+    rsync (1.0.9)
+    safe_yaml (1.0.4)
+    semantic_puppet (0.1.4)
+      gettext-setup (>= 0.3)
+    spdx-licenses (1.1.0)
+    text (1.3.1)
+    thor (0.19.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  librarian-puppet
+  metadata-json-lint
+  puppet (< 4)
+  puppet-lint
+  puppet-syntax
+  puppetlabs_spec_helper
+  rspec
+  rspec-puppet
+  safe_yaml (>= 1.0.4)
+
+BUNDLED WITH
+   1.13.5

--- a/gemfiles/puppet4.gemfile
+++ b/gemfiles/puppet4.gemfile
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+gem 'puppet', '~> 4.0'
+gem 'safe_yaml', '>= 1.0.4'
+gem 'librarian-puppet'
+
+group :development, :test do
+  gem "metadata-json-lint"
+  gem "puppet-lint"
+  gem "puppet-syntax"
+  gem "puppetlabs_spec_helper"
+  gem "rspec"
+  gem "rspec-puppet"
+end

--- a/gemfiles/puppet4.gemfile.lock
+++ b/gemfiles/puppet4.gemfile.lock
@@ -1,0 +1,99 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.3)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
+    fast_gettext (1.1.0)
+    gettext (3.2.2)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.24)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
+      locale
+    hiera (3.3.1)
+    json (2.1.0)
+    json_pure (1.8.6)
+    librarian-puppet (2.2.3)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 2.1)
+      rsync
+    librarianp (0.6.3)
+      thor (~> 0.15)
+    locale (2.1.2)
+    metaclass (0.0.4)
+    metadata-json-lint (1.1.0)
+      json
+      semantic_puppet (>= 0.1.2, < 2.0.0)
+      spdx-licenses (~> 1.0)
+    minitar (0.6.1)
+    mocha (1.2.1)
+      metaclass (~> 0.0.1)
+    multipart-post (2.0.0)
+    puppet (4.10.0)
+      CFPropertyList (~> 2.2.6)
+      facter (> 2.0, < 4)
+      gettext-setup (>= 0.10, < 1)
+      hiera (>= 2.0, < 4)
+      json_pure (~> 1.8)
+      locale (~> 2.1)
+    puppet-lint (2.2.1)
+    puppet-syntax (2.4.0)
+      rake
+    puppet_forge (2.2.4)
+      faraday (~> 0.9.0)
+      faraday_middleware (>= 0.9.0, < 0.11.0)
+      gettext-setup (~> 0.11)
+      minitar
+      semantic_puppet (~> 0.1.0)
+    puppetlabs_spec_helper (2.1.2)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
+    rake (12.0.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-puppet (2.5.0)
+      rspec
+    rspec-support (3.5.0)
+    rsync (1.0.9)
+    safe_yaml (1.0.4)
+    semantic_puppet (0.1.4)
+      gettext-setup (>= 0.3)
+    spdx-licenses (1.1.0)
+    text (1.3.1)
+    thor (0.19.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  librarian-puppet
+  metadata-json-lint
+  puppet (~> 4.0)
+  puppet-lint
+  puppet-syntax
+  puppetlabs_spec_helper
+  rspec
+  rspec-puppet
+  safe_yaml (>= 1.0.4)
+
+BUNDLED WITH
+   1.13.5

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,11 +1,10 @@
 # Class to manage NGinx configs
 define nginx::config(
   $ensure  = 'present',
-  $source  = '',
-  $content = '',
+  $source  = undef,
+  $content = undef,
   $path    = "/etc/nginx/conf.d/${name}.conf",
 ) {
-
   validate_string($source, $content)
 
   if ($ensure != 'present' and $ensure != 'absent') {

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,9 +1,10 @@
 # Class to manage site resources
 define nginx::site(
   $ensure  = 'present',
-  $source  = '',
-  $content = '',
+  $source  = undef,
+  $content = undef,
 ) {
+  validate_string($source, $content)
 
   File {
     ensure => $ensure ? {

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -13,6 +13,17 @@ describe 'nginx::config' do
     it { is_expected.not_to compile }
   end
 
+  context "with source and content both specified" do
+    let(:params) {
+      {
+        :source  => '/home/foo.conf',
+        :content => 'foo',
+      }
+    }
+
+    it { is_expected.not_to compile }
+  end
+
   context "with source specified" do
     let(:params) { {:source => '/home/foo.conf'} }
 


### PR DESCRIPTION
This change in Puppet 4 breaks the module -
 https://docs.puppet.com/puppet/4.10/lang_updating_manifests.html#empty-strings-in-boolean-context-are-true.

```
F..FF....FFFFFFFF

Failures:

  1) nginx should compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile }
       error during compilation: Parameter source failed on File[/etc/nginx/sites-available/default]: Cannot use relative URLs '' at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/site.pp:26
     # ./spec/classes/nginx_spec.rb:4:in `block (2 levels) in <top (required)>'

  2) nginx with config nginx class should compile should compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile }
       error during compilation: Parameter source failed on File[/etc/nginx/sites-available/default]: Cannot use relative URLs '' at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/site.pp:26
     # ./spec/classes/nginx_spec.rb:20:in `block (3 levels) in <top (required)>'

  3) nginx with content nginx class should compile should compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile }
       error during compilation: Parameter source failed on File[/etc/nginx/sites-available/default]: Cannot use relative URLs '' at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/site.pp:26
     # ./spec/classes/nginx_spec.rb:26:in `block (3 levels) in <top (required)>'

  4) nginx::config with source specified should compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile }
       error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Nginx::Config[foo] cannot specify both source and content at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/config.pp:19:5 at line 3 on node syd-mbp-ward.syd1bc.bigcommerce.net
     # ./spec/defines/config_spec.rb:30:in `block (3 levels) in <top (required)>'

  5) nginx::config with source specified should contain Nginx::Config[foo]
     Failure/Error: fail("Nginx::Config[${name}] cannot specify both source and content")

     Puppet::PreformattedError:
       Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Nginx::Config[foo] cannot specify both source and content at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/config.pp:19:5 at line 3 on node syd-mbp-ward.syd1bc.bigcommerce.net
     # ./spec/fixtures/modules/nginx/manifests/config.pp:19:in `stack'
     # ./spec/defines/config_spec.rb:31:in `block (3 levels) in <top (required)>'

  6) nginx::config with source specified should contain File[/etc/nginx/conf.d/foo.conf] with source => "/home/foo.conf"
     Failure/Error: fail("Nginx::Config[${name}] cannot specify both source and content")

     Puppet::PreformattedError:
       Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Nginx::Config[foo] cannot specify both source and content at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/config.pp:19:5 at line 3 on node syd-mbp-ward.syd1bc.bigcommerce.net
     # ./spec/fixtures/modules/nginx/manifests/config.pp:19:in `stack'
     # ./spec/defines/config_spec.rb:32:in `block (3 levels) in <top (required)>'

  7) nginx::config with source specified and custom path should contain File[/etc/nginx/my_config.conf] with source => "/home/foo.conf"
     Failure/Error: fail("Nginx::Config[${name}] cannot specify both source and content")

     Puppet::PreformattedError:
       Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Nginx::Config[foo] cannot specify both source and content at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/config.pp:19:5 at line 3 on node syd-mbp-ward.syd1bc.bigcommerce.net
     # ./spec/fixtures/modules/nginx/manifests/config.pp:19:in `stack'
     # ./spec/defines/config_spec.rb:41:in `block (4 levels) in <top (required)>'

  8) nginx::config with content specified should compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile }
       error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Nginx::Config[foo] cannot specify both source and content at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/config.pp:19:5 at line 3 on node syd-mbp-ward.syd1bc.bigcommerce.net
     # ./spec/defines/config_spec.rb:48:in `block (3 levels) in <top (required)>'

  9) nginx::config with content specified should contain Nginx::Config[foo]
     Failure/Error: fail("Nginx::Config[${name}] cannot specify both source and content")

     Puppet::PreformattedError:
       Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Nginx::Config[foo] cannot specify both source and content at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/config.pp:19:5 at line 3 on node syd-mbp-ward.syd1bc.bigcommerce.net
     # ./spec/fixtures/modules/nginx/manifests/config.pp:19:in `stack'
     # ./spec/defines/config_spec.rb:49:in `block (3 levels) in <top (required)>'

  10) nginx::config with content specified should contain File[/etc/nginx/conf.d/foo.conf] with content  supplied string
      Failure/Error: fail("Nginx::Config[${name}] cannot specify both source and content")

      Puppet::PreformattedError:
        Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Nginx::Config[foo] cannot specify both source and content at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/config.pp:19:5 at line 3 on node syd-mbp-ward.syd1bc.bigcommerce.net
      # ./spec/fixtures/modules/nginx/manifests/config.pp:19:in `stack'
      # ./spec/defines/config_spec.rb:50:in `block (3 levels) in <top (required)>'

  11) nginx::config with content specified and custom path should contain File[/etc/nginx/my_config.conf] with content  supplied string
      Failure/Error: fail("Nginx::Config[${name}] cannot specify both source and content")

      Puppet::PreformattedError:
        Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Nginx::Config[foo] cannot specify both source and content at /Volumes/Code/Projects/puppet-nginx/spec/fixtures/modules/nginx/manifests/config.pp:19:5 at line 3 on node syd-mbp-ward.syd1bc.bigcommerce.net
      # ./spec/fixtures/modules/nginx/manifests/config.pp:19:in `stack'
      # ./spec/defines/config_spec.rb:59:in `block (4 levels) in <top (required)>'

Finished in 4 seconds (files took 1.17 seconds to load)
17 examples, 11 failures

Failed examples:

rspec ./spec/classes/nginx_spec.rb:4 # nginx should compile into a catalogue without dependency cycles
rspec ./spec/classes/nginx_spec.rb:20 # nginx with config nginx class should compile should compile into a catalogue without dependency cycles
rspec ./spec/classes/nginx_spec.rb:26 # nginx with content nginx class should compile should compile into a catalogue without dependency cycles
rspec ./spec/defines/config_spec.rb:30 # nginx::config with source specified should compile into a catalogue without dependency cycles
rspec ./spec/defines/config_spec.rb:31 # nginx::config with source specified should contain Nginx::Config[foo]
rspec ./spec/defines/config_spec.rb:32 # nginx::config with source specified should contain File[/etc/nginx/conf.d/foo.conf] with source => "/home/foo.conf"
rspec ./spec/defines/config_spec.rb:41 # nginx::config with source specified and custom path should contain File[/etc/nginx/my_config.conf] with source => "/home/foo.conf"
rspec ./spec/defines/config_spec.rb:48 # nginx::config with content specified should compile into a catalogue without dependency cycles
rspec ./spec/defines/config_spec.rb:49 # nginx::config with content specified should contain Nginx::Config[foo]
rspec ./spec/defines/config_spec.rb:50 # nginx::config with content specified should contain File[/etc/nginx/conf.d/foo.conf] with content  supplied string
rspec ./spec/defines/config_spec.rb:59 # nginx::config with content specified and custom path should contain File[/etc/nginx/my_config.conf] with content  supplied string
```

Fixed by changing the `$source` and `$content` params to `undef` which maintains the existing behaviour of allowing either param to not be specified.

```
.................

Finished in 2.54 seconds (files took 0.65753 seconds to load)
17 examples, 0 failures
```