### PR TITLE
Add refreshonly param to the rebuild-nginx-upstream exec.

### DIFF
--- a/manifests/upstream.pp
+++ b/manifests/upstream.pp
@@ -72,8 +72,9 @@ define nginx::upstream(
   }
 
   exec { "rebuild-nginx-upstream-${name}":
-    command => $command,
-    require => File[$target_dir],
-    notify  => Service['nginx'],
+    command     => $command,
+    require     => File[$target_dir],
+    notify      => Service['nginx'],
+    refreshonly => true,
   }
 }


### PR DESCRIPTION
This ensures the config is only rebuilt and nginx reloaded only when the upstream has changed.