### PR TITLE
Update with future parser compatibility changes

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -2,7 +2,7 @@
 define nginx::site(
   $ensure  = 'present',
   $source  = undef,
-  $content = undef,
+  $content = '',
 ) {
   validate_string($source, $content)
 
@@ -25,12 +25,11 @@ define nginx::site(
 
   $config_file = "/etc/nginx/sites-available/${name}"
 
-  if ($source != '') {
+  if ($source) {
     file { $config_file:
       source => $source,
     }
-  }
-  elsif ($content != '') {
+  } else {
     file { $config_file:
       content => $content,
     }
@@ -40,8 +39,7 @@ define nginx::site(
     file { "/etc/nginx/sites-enabled/${name}":
       ensure => $config_file,
     }
-  }
-  else {
+  } else {
     file { "/etc/nginx/sites-enabled/${name}":
       ensure => 'absent',
       # This should still notify the service, as a reload will not


### PR DESCRIPTION
Fixes the future parser attempting to declare a new resource when removing the default site:


```
             "type": "File",
    +        "title": "/etc/nginx/sites-available/default",
    +        "tags": [
    +          "file",
    +          "nginx::site",
    +          "nginx",
    +          "site",
    +          "default",
    +          "class",
    +        ],
    +        "file": "/opt/puppet_envs/production/librarian-modules/nginx/manifests/site.pp",
    +        "line": 29,
    +        "exported": false,
    +        "parameters": {
    +          "ensure": "absent",
    +          "owner": "root",
    +          "group": "root",
    +          "mode": "0640",
    +          "notify": "Service[nginx]",
    +          "require": [
    +            "File[/etc/nginx/sites-available]",
    +            "File[/etc/nginx/sites-enabled]"
    +          ]
    +        }
```