### PR TITLE
Increase hash bucket size to 128 - fixes alerts on bigpay-app

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -15,6 +15,7 @@ http {
 	sendfile on;
 	server_names_hash_bucket_size 64;
 	types_hash_max_size 2048;
+  variables_hash_bucket_size 128;
 	#tcp_nopush	 on;
 
 	log_format vhost_combined '$server_name $remote_addr - $remote_user [$time_local]  '


### PR DESCRIPTION
Fixes the bucket size warnings on bigpay-app nginx hosts. Nginx hash documentation suggests that incorrect or suboptimal sizes may result in excessive lookup and I am being pedantic because I dislike the errors.

## Before
```[integration][us-central1][bigpay_app_gcp][root@bigpay-app-4936b215]:~# nginx -t
nginx: [warn] could not build optimal variables_hash, you should increase either variables_hash_max_size: 1024 or variables_hash_bucket_size: 64; ignoring variables_hash_bucket_size
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
```

## After
```
[integration][us-central1][bigpay_app_gcp][root@bigpay-app-4936b215]:~# nginx -t
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```