### PR TITLE
Allow setting max_fails, fail_timeout and weight to zero

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,7 @@
+fixtures:
+  repositories:
+    stdlib:
+      repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
+      ref: '5.0.0'
+  symlinks:
+    nginx: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1
-  - 2.2
+  - 2.5
+  - 2.6
 gemfile:
   - gemfiles/puppet3.gemfile
   - gemfiles/puppet4.gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -17,27 +17,4 @@ RSpec::Core::RakeTask.new(:spec_standalone) do |t|
   t.pattern = 'spec/**/*_spec.rb'
 end
 
-Rake::Task[:spec_prep].clear
-desc 'Create the fixtures directory'
-task :spec_prep do
-  FileUtils::mkdir_p('spec/fixtures/modules/nginx')
-  FileUtils::mkdir_p('spec/fixtures/manifests')
-  FileUtils.chdir('spec/fixtures/modules/nginx') do
-    %w(files manifests templates).each do |dir|
-      FileUtils::ln_sf("../../../../#{dir}", '.')
-    end
-  end
-  FileUtils::touch('spec/fixtures/manifests/site.pp')
-  sh 'librarian-puppet install --path=spec/fixtures/modules'
-end
-
-Rake::Task[:spec_clean].clear
-desc 'Clean up the fixtures directory'
-task :spec_clean do
-  #sh 'librarian-puppet clean'
-  if File.zero?('spec/fixtures/manifests/site.pp')
-    FileUtils::rm_f('spec/fixtures/manifests/site.pp')
-  end
-end
-
 PuppetSyntax.exclude_paths = ["vendor/**/*", "gemfiles/vendor/**/*", "spec/fixtures/modules/**/*"]

--- a/gemfiles/puppet3.gemfile
+++ b/gemfiles/puppet3.gemfile
@@ -11,4 +11,5 @@ group :development, :test do
   gem "puppetlabs_spec_helper"
   gem "rspec"
   gem "rspec-puppet"
+  gem "xmlrpc"
 end

--- a/gemfiles/puppet3.gemfile.lock
+++ b/gemfiles/puppet3.gemfile.lock
@@ -78,6 +78,7 @@ GEM
     spdx-licenses (1.1.0)
     text (1.3.1)
     thor (0.19.4)
+    xmlrpc (0.3.0)
 
 PLATFORMS
   ruby
@@ -92,6 +93,7 @@ DEPENDENCIES
   rspec
   rspec-puppet
   safe_yaml (>= 1.0.4)
+  xmlrpc
 
 BUNDLED WITH
-   1.13.5
+   1.17.2

--- a/manifests/upstream/member.pp
+++ b/manifests/upstream/member.pp
@@ -4,9 +4,9 @@ define nginx::upstream::member(
   $ensure       = 'present',
   $host         = '',
   $down         = false,
-  $weight       = 1,
-  $max_fails    = 0,
-  $fail_timeout = 0,
+  $weight       = undef,
+  $max_fails    = undef,
+  $fail_timeout = undef,
   $backup       = false
 ) {
 

--- a/spec/defines/upstream/member_spec.rb
+++ b/spec/defines/upstream/member_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'nginx::upstream::member' do
+  upstream_name = 'upstream_test'
+  upstream_member_name = 'upstream_member_1'
+  upstream_conf_file = "/etc/nginx/upstreams.d/#{upstream_name}/1_#{upstream_member_name}.conf"
+
+  let(:pre_condition) do
+    'nginx::upstream {"' + upstream_name + '": }'
+  end
+
+  let(:title) { upstream_member_name }
+
+  let(:params) do 
+    {
+      'upstream' => upstream_name
+    }
+  end
+
+  it { is_expected.to compile }
+  it { is_expected.to contain_nginx__upstream__member(upstream_member_name) }
+
+  context "without weight, max_fails, fail_timeout set" do
+    let(:params) do
+      {
+        'upstream' => upstream_name
+      }
+    end
+
+    it do
+      is_expected.to contain_file(upstream_conf_file) \
+        .with_content(/server/)
+      is_expected.to contain_file(upstream_conf_file) \
+        .without_content(/max_fails=/)
+    end
+  end
+
+  context "with weight, max_fails, fail_timeout set" do
+    let(:params) do
+      {
+        'upstream'     => upstream_name,
+        'weight'       => 100,
+        'max_fails'    => 0,
+        'fail_timeout' => 10,
+      }
+    end
+
+    it do
+      is_expected.to contain_file(upstream_conf_file) \
+        .with_content(/weight=/)
+      is_expected.to contain_file(upstream_conf_file) \
+        .with_content(/max_fails=/)
+      is_expected.to contain_file(upstream_conf_file) \
+        .with_content(/fail_timeout=/)
+    end
+  end
+end

--- a/templates/upstream.member.erb
+++ b/templates/upstream.member.erb
@@ -1,6 +1,6 @@
   server <%= @use_host -%>
-<%= " weight=#{@weight}" if @weight.to_i > 1 -%>
-<%= " max_fails=#{@max_fails}" if @max_fails.to_i > 0 -%>
-<%= " fail_timeout=#{@fail_timeout}" if @fail_timeout.to_i > 0 -%>
+<%= " weight=#{@weight}" if @weight -%>
+<%= " max_fails=#{@max_fails}" if @max_fails -%>
+<%= " fail_timeout=#{@fail_timeout}" if @fail_timeout -%>
 <%= " down" if @down == true -%>
 <%= " backup" if @backup == true -%>; # <%= @name %>


### PR DESCRIPTION
This allows setting max_fails, fail_timeout and weight to `0`. The default values for these settings were change to undef. This results in the same default behavior of not including `max_fails`, `fail_timeout` and `weight` unless those value are explicitly set.

Other changes:
Added `.fixtures.yml` for the rspec tests
Added a rspec test for the defined type `nginx::upstream::member`
Remove unnecessary `spec_prep` and `clear` code from Rakefile
Changed ruby versions in `.travis.yml`
Add xmlrpc to `gemfiles/puppet3.gemfile` to allow test to work in Puppet 3

rspec run:
```
% bundle exec rake spec                                                
Cloning into 'spec/fixtures/modules/stdlib'...
remote: Enumerating objects: 16, done.
remote: Counting objects: 100% (16/16), done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 14894 (delta 2), reused 5 (delta 0), pack-reused 14878
Receiving objects: 100% (14894/14894), 3.34 MiB | 931.00 KiB/s, done.
Resolving deltas: 100% (8398/8398), done.
.......................

Finished in 1.86 seconds (files took 0.57447 seconds to load)
23 examples, 0 failures

```

